### PR TITLE
Add support for v4 feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDEs
+.idea

--- a/go/report/report.go
+++ b/go/report/report.go
@@ -7,11 +7,12 @@ import (
 	v1 "github.com/smartcontractkit/data-streams-sdk/go/report/v1"
 	v2 "github.com/smartcontractkit/data-streams-sdk/go/report/v2"
 	v3 "github.com/smartcontractkit/data-streams-sdk/go/report/v3"
+	v4 "github.com/smartcontractkit/data-streams-sdk/go/report/v4"
 )
 
 // Data represents the actual report data and attributes
 type Data interface {
-	v1.Data | v2.Data | v3.Data
+	v1.Data | v2.Data | v3.Data | v4.Data
 	Schema() abi.Arguments
 }
 

--- a/go/report/report_test.go
+++ b/go/report/report_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/smartcontractkit/data-streams-sdk/go/report/v1"
 	v2 "github.com/smartcontractkit/data-streams-sdk/go/report/v2"
 	v3 "github.com/smartcontractkit/data-streams-sdk/go/report/v3"
+	v4 "github.com/smartcontractkit/data-streams-sdk/go/report/v4"
 )
 
 func TestReport(t *testing.T) {
@@ -39,7 +40,7 @@ func TestReport(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(v2Report, rv2) {
-		t.Errorf("expected: %#v, got: %#v", v1Report, rv1)
+		t.Errorf("expected: %#v, got: %#v", v2Report, rv2)
 	}
 
 	b, err = schema.Pack(v3Report.ReportContext, v3Report.ReportBlob, v3Report.RawRs, v3Report.RawSs, v3Report.RawVs)
@@ -53,7 +54,21 @@ func TestReport(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(v3Report, rv3) {
-		t.Errorf("expected: %#v, got: %#v", v1Report, rv1)
+		t.Errorf("expected: %#v, got: %#v", v3Report, rv3)
+	}
+
+	b, err = schema.Pack(v4Report.ReportContext, v4Report.ReportBlob, v4Report.RawRs, v4Report.RawSs, v4Report.RawVs)
+	if err != nil {
+		t.Errorf("failed to encode report: %s", err)
+	}
+
+	rv4, err := Decode[v4.Data](b)
+	if err != nil {
+		t.Errorf("failed to decode report: %s", err)
+	}
+
+	if !reflect.DeepEqual(v4Report, rv4) {
+		t.Errorf("expected: %#v, got: %#v", v4Report, rv4)
 	}
 }
 
@@ -84,6 +99,15 @@ var v3Report = &Report[v3.Data]{
 	RawVs:         [32]uint8{00, 01, 10, 74, 67, 29, 24, 17, 12, 18, 22, 11, 69, 11, 63, 86, 12, 86, 23, 58, 13, 53, 29, 12, 17, 10, 17, 12, 63, 27, 12, 14},
 }
 
+var v4Report = &Report[v4.Data]{
+	Data:          v4Data,
+	ReportContext: [3][32]uint8{},
+	ReportBlob:    mustPackData(v4Data),
+	RawRs:         [][32]uint8{{00, 01, 10, 74, 67, 29, 24, 17, 12, 18, 22, 11, 69, 11, 63, 86, 12, 86, 23, 58, 13, 53, 29, 12, 17, 10, 17, 12, 63, 27, 12, 14}},
+	RawSs:         [][32]uint8{{01, 02, 10, 73, 65, 19, 14, 27, 42, 48, 52, 18, 39, 116, 67, 85, 13, 82, 33, 48, 23, 33, 49, 32, 67, 50, 37, 32, 63, 77, 14, 64}},
+	RawVs:         [32]uint8{00, 01, 10, 74, 67, 29, 24, 17, 12, 18, 22, 11, 69, 11, 63, 86, 12, 86, 23, 58, 13, 53, 29, 12, 17, 10, 17, 12, 63, 27, 12, 14},
+}
+
 var v1Data = v1.Data{
 	FeedID:                [32]uint8{00, 01, 107, 74, 167, 229, 124, 167, 182, 138, 225, 191, 69, 101, 63, 86, 182, 86, 253, 58, 163, 53, 239, 127, 174, 105, 107, 102, 63, 27, 132, 114},
 	ObservationsTimestamp: uint32(time.Now().Unix()),
@@ -93,7 +117,8 @@ var v1Data = v1.Data{
 	CurrentBlockNum:       100,
 	CurrentBlockHash:      [32]uint8{0, 0, 7, 4, 7, 2, 4, 1, 82, 38, 2, 9, 6, 5, 6, 8, 2, 8, 5, 5, 163, 53, 239, 127, 174, 105, 107, 102, 63, 27, 132, 1},
 	ValidFromBlockNum:     768986,
-	CurrentBlockTimestamp: uint64(time.Now().Unix())}
+	CurrentBlockTimestamp: uint64(time.Now().Unix()),
+}
 
 var v2Data = v2.Data{
 	FeedID:                [32]uint8{00, 02, 107, 74, 167, 229, 124, 167, 182, 138, 225, 191, 69, 101, 63, 86, 182, 86, 253, 58, 163, 53, 239, 127, 174, 105, 107, 102, 63, 27, 132, 114},
@@ -115,6 +140,17 @@ var v3Data = v3.Data{
 	BenchmarkPrice:        big.NewInt(100),
 	Bid:                   big.NewInt(100),
 	Ask:                   big.NewInt(100),
+}
+
+var v4Data = v4.Data{
+	FeedID:                [32]uint8{00, 04, 107, 74, 167, 229, 124, 167, 182, 138, 225, 191, 69, 101, 63, 86, 182, 86, 253, 58, 163, 53, 239, 127, 174, 105, 107, 102, 63, 27, 132, 114},
+	ValidFromTimestamp:    uint32(time.Now().Unix()),
+	ObservationsTimestamp: uint32(time.Now().Unix()),
+	NativeFee:             big.NewInt(10),
+	LinkFee:               big.NewInt(10),
+	ExpiresAt:             uint32(time.Now().Unix()) + 100,
+	BenchmarkPrice:        big.NewInt(100),
+	MarketStatus:          v4.MarketStatusOpen,
 }
 
 func mustPackData(d interface{}) []byte {
@@ -144,7 +180,8 @@ func mustPackData(d interface{}) []byte {
 			v.NativeFee,
 			v.LinkFee,
 			v.ExpiresAt,
-			v.BenchmarkPrice}
+			v.BenchmarkPrice,
+		}
 	case v3.Data:
 		dataSchema = v3.Schema()
 		args = []interface{}{
@@ -156,7 +193,20 @@ func mustPackData(d interface{}) []byte {
 			v.ExpiresAt,
 			v.BenchmarkPrice,
 			v.Bid,
-			v.Ask}
+			v.Ask,
+		}
+	case v4.Data:
+		dataSchema = v4.Schema()
+		args = []interface{}{
+			v.FeedID,
+			v.ValidFromTimestamp,
+			v.ObservationsTimestamp,
+			v.NativeFee,
+			v.LinkFee,
+			v.ExpiresAt,
+			v.BenchmarkPrice,
+			v.MarketStatus,
+		}
 	default:
 		panic(fmt.Sprintf("invalid type to pack: %#v", v))
 	}

--- a/go/report/v4/data.go
+++ b/go/report/v4/data.go
@@ -1,0 +1,68 @@
+package v4
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/smartcontractkit/data-streams-sdk/go/feed"
+)
+
+var schema = Schema()
+
+// Schema returns this data version schema
+func Schema() abi.Arguments {
+	mustNewType := func(t string) abi.Type {
+		result, err := abi.NewType(t, "", []abi.ArgumentMarshaling{})
+		if err != nil {
+			panic(fmt.Sprintf("Unexpected error during abi.NewType: %s", err))
+		}
+		return result
+	}
+	return abi.Arguments([]abi.Argument{
+		{Name: "feedId", Type: mustNewType("bytes32")},
+		{Name: "validFromTimestamp", Type: mustNewType("uint32")},
+		{Name: "observationsTimestamp", Type: mustNewType("uint32")},
+		{Name: "nativeFee", Type: mustNewType("uint192")},
+		{Name: "linkFee", Type: mustNewType("uint192")},
+		{Name: "expiresAt", Type: mustNewType("uint32")},
+		{Name: "benchmarkPrice", Type: mustNewType("int192")},
+		{Name: "marketStatus", Type: mustNewType("uint32")},
+	})
+}
+
+const (
+	MarketStatusUnknown uint32 = iota
+	MarketStatusClosed
+	MarketStatusOpen
+)
+
+// Data is the container for this schema attributes
+type Data struct {
+	FeedID                feed.ID `abi:"feedId"`
+	ObservationsTimestamp uint32
+	BenchmarkPrice        *big.Int
+	MarketStatus          uint32
+	ValidFromTimestamp    uint32
+	ExpiresAt             uint32
+	LinkFee               *big.Int
+	NativeFee             *big.Int
+}
+
+// Schema returns this data version schema
+func (Data) Schema() abi.Arguments {
+	return Schema()
+}
+
+// Decode decodes the serialized data bytes
+func Decode(data []byte) (*Data, error) {
+	values, err := schema.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode report: %w", err)
+	}
+	decoded := new(Data)
+	if err = schema.Copy(decoded, values); err != nil {
+		return nil, fmt.Errorf("failed to copy report values to struct: %w", err)
+	}
+	return decoded, nil
+}

--- a/go/report/v4/data_test.go
+++ b/go/report/v4/data_test.go
@@ -1,0 +1,45 @@
+package v4
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestData(t *testing.T) {
+	r := &Data{
+		FeedID:                [32]uint8{00, 04, 107, 74, 167, 229, 124, 167, 182, 138, 225, 191, 69, 101, 63, 86, 182, 86, 253, 58, 163, 53, 239, 127, 174, 105, 107, 102, 63, 27, 132, 114},
+		ValidFromTimestamp:    uint32(time.Now().Unix()),
+		ObservationsTimestamp: uint32(time.Now().Unix()),
+		NativeFee:             big.NewInt(10),
+		LinkFee:               big.NewInt(10),
+		ExpiresAt:             uint32(time.Now().Unix()) + 100,
+		BenchmarkPrice:        big.NewInt(100),
+		MarketStatus:          MarketStatusOpen,
+	}
+
+	b, err := schema.Pack(
+		r.FeedID,
+		r.ValidFromTimestamp,
+		r.ObservationsTimestamp,
+		r.NativeFee,
+		r.LinkFee,
+		r.ExpiresAt,
+		r.BenchmarkPrice,
+		r.MarketStatus,
+	)
+
+	if err != nil {
+		t.Errorf("failed to serialize report: %s", err)
+	}
+
+	d, err := Decode(b)
+	if err != nil {
+		t.Errorf("failed to deserialize report: %s", err)
+	}
+
+	if !reflect.DeepEqual(r, d) {
+		t.Errorf("expected: %#v, got %#v", r, d)
+	}
+}


### PR DESCRIPTION
Adding support for Mercury report schema v4. Key difference from v3 is that there is no bid/ask prices and there is a new enum valued market status field.