### PR TITLE
fix: Add FeedVersion8 and FeedVersion9 to FeedVersion enum

### DIFF
--- a/go/feed/feed.go
+++ b/go/feed/feed.go
@@ -15,6 +15,8 @@ const (
 	FeedVersion2
 	FeedVersion3
 	FeedVersion4
+	FeedVersion8
+	FeedVersion9
 	_
 )
 


### PR DESCRIPTION
### Changes
- Added `FeedVersion8` and `FeedVersion9` to the `FeedVersion` enum in `feed.go`.

### Testing
- Verified that the `FeedVersion` enum now includes the new versions.
