### PR TITLE
Prepare chainlink_data_streams_sdk crate for v1.0.1 release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chainlink-data-streams-report"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "hex",
  "num-bigint",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "chainlink-data-streams-sdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "chainlink-data-streams-report",

--- a/rust/crates/sdk/Cargo.toml
+++ b/rust/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainlink-data-streams-sdk"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.70"
 description = "Chainlink Data Streams client SDK"
@@ -11,7 +11,7 @@ exclude = ["/target/*", "examples/*", "tests/*", "docs/*", "book/*"]
 keywords = ["chainlink"]
 
 [dependencies]
-chainlink-data-streams-report = { path = "../report", version = "1.0.0" }
+chainlink-data-streams-report = { path = "../report", version = "1.0.1" }
 reqwest = { version = "0.11.20", features = ["json", "rustls-tls"] }
 tokio = { version = "1.29.1", features = ["full"] }
 tokio-tungstenite = { version = "0.20.1", features = [


### PR DESCRIPTION
This PR prepares `chainlink_data_streams_sdk` crate for v1.0.1 release for backward compatibility reasons