### PR TITLE
Exports auth headers function

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlink/data-streams-sdk",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlink/data-streams-sdk",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "ethers": "^6.15.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/data-streams-sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TypeScript SDK for Chainlink Data Streams",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -69,9 +69,9 @@ export { ConnectionStatus } from "./types/metrics";
 export * from "./types/errors";
 
 // Utility Functions
-export { 
-  // Report utilities 
-  getReportVersion, 
+export {
+  // Report utilities
+  getReportVersion,
   formatReport,
   // Time utilities
   getCurrentTimestamp,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -75,6 +75,8 @@ export {
   formatReport,
   // Time utilities
   getCurrentTimestamp,
+  // Authentication Headers
+  generateAuthHeaders,
 } from "./utils";
 
 // Constants


### PR DESCRIPTION
This PR exports the generateAuthHeaders function for external use.

### Background
[OPDATA-2540](https://smartcontract-it.atlassian.net/browse/OPDATA-2540)

### Testing
Ran unit tests via `npm test`

[OPDATA-2540]: https://smartcontract-it.atlassian.net/browse/OPDATA-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ