### PR TITLE
Fix publish environment

### DIFF
--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: publish
+    environment: publish-npm
     defaults:
       run:
         working-directory: ./typescript


### PR DESCRIPTION
This fix should allow us to resume publishing TS packages via the GHA.