### PR TITLE
Add User-Agent header derived from Go BuildInfo

### DIFF
--- a/go/auth.go
+++ b/go/auth.go
@@ -30,3 +30,8 @@ func generateAuthHeaders(h http.Header, method string, path string, body []byte,
 	h.Add(authzTSHeader, strconv.FormatInt(timestamp, 10))
 	h.Add(authzSigHeader, hmacString)
 }
+
+func setRequestHeaders(h http.Header, method string, path string, body []byte, clientId string, userSecret string, timestamp int64) {
+	h.Set("User-Agent", userAgent())
+	generateAuthHeaders(h, method, path, body, clientId, userSecret, timestamp)
+}

--- a/go/client.go
+++ b/go/client.go
@@ -285,7 +285,7 @@ func (c *client) rest(ctx context.Context, d *request, dst interface{}) (err err
 		return err
 	}
 
-	generateAuthHeaders(req.Header, req.Method, reqURL.RequestURI(), d.body,
+	setRequestHeaders(req.Header, req.Method, reqURL.RequestURI(), d.body,
 		c.config.ApiKey, c.config.ApiSecret, time.Now().UnixMilli())
 
 	if value := ctx.Value(CustomHeadersCtxKey); value != nil {
@@ -357,7 +357,7 @@ func (c *client) serverHeaders(ctx context.Context, u *url.URL) (h http.Header, 
 		return nil, err
 	}
 
-	generateAuthHeaders(req.Header, req.Method, reqURL.RequestURI(), nil,
+	setRequestHeaders(req.Header, req.Method, reqURL.RequestURI(), nil,
 		c.config.ApiKey, c.config.ApiSecret, time.Now().UnixMilli())
 
 	c.config.logDebug(

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -494,9 +494,11 @@ func TestUserAgentSentInRequests(t *testing.T) {
 		t.Fatalf("error creating client: %s", err)
 	}
 
-	_, _ = client.GetFeeds(context.Background())
+	_, err = client.GetFeeds(context.Background())
+	if err != nil {
+		t.Fatalf("GetFeeds() error = %v", err)
+	}
 }
-
 
 type mockServer struct {
 	server *httptest.Server

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -465,6 +466,37 @@ func Test_extractOrigins(t *testing.T) {
 		})
 	}
 }
+
+func TestUserAgent(t *testing.T) {
+	ua := userAgent()
+	t.Logf("User-Agent: %s", ua)
+	if ua == "" {
+		t.Fatal("userAgent() returned empty string")
+	}
+	if !strings.HasPrefix(ua, "data-streams-sdk-go/") {
+		t.Errorf("userAgent() = %q, want prefix %q", ua, "data-streams-sdk-go/")
+	}
+}
+
+func TestUserAgentSentInRequests(t *testing.T) {
+	ms := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("User-Agent")
+		if !strings.HasPrefix(got, "data-streams-sdk-go/") {
+			t.Errorf("User-Agent header = %q, want prefix %q", got, "data-streams-sdk-go/")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(feedsResponse{Feeds: []*feed.Feed{}}) //nolint:errcheck
+	})
+	defer ms.Close()
+
+	client, err := ms.Client()
+	if err != nil {
+		t.Fatalf("error creating client: %s", err)
+	}
+
+	_, _ = client.GetFeeds(context.Background())
+}
+
 
 type mockServer struct {
 	server *httptest.Server

--- a/go/stream.go
+++ b/go/stream.go
@@ -424,7 +424,7 @@ func (s *stream) newWSconn(ctx context.Context, origin string) (ws *wsConn, err 
 	reqURL.RawQuery = url.Values{"feedIDs": {strings.Join(feedIdsToStringList(s.feedIDs), ",")}}.Encode()
 
 	headers := http.Header{}
-	generateAuthHeaders(headers, http.MethodGet, reqURL.RequestURI(), nil,
+	setRequestHeaders(headers, http.MethodGet, reqURL.RequestURI(), nil,
 		s.config.ApiKey, s.config.ApiSecret, time.Now().UnixMilli())
 
 	if origin != "" {

--- a/go/version.go
+++ b/go/version.go
@@ -1,0 +1,29 @@
+package streams
+
+import (
+	"runtime/debug"
+	"strings"
+	"sync"
+)
+
+const modulePath = "github.com/smartcontractkit/data-streams-sdk/go"
+
+func matchesModule(path string) bool {
+	return path == modulePath || strings.HasPrefix(path, modulePath+"/v")
+}
+
+// userAgent returns this Go SDK version and is appended to the User-Agent header for all requests.
+// this is wrapped in sync.OnceValue to avoid repeated expensive calls to debug.ReadBuildInfo.
+var userAgent = sync.OnceValue(func() string {
+	version := "unknown"
+	bi, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, dep := range bi.Deps {
+			if matchesModule(dep.Path) {
+				version = dep.Version
+				break
+			}
+		}
+	}
+	return "data-streams-sdk-go/" + version
+})


### PR DESCRIPTION
Borrowed from planetscale-go sdk
- [PlanetScale Blog: Versioning User-Agent Headers in Go](https://iheanyi.com/journal/versioning-user-agent-headers-in-go/)
- [Implementation](https://github.com/planetscale/planetscale-go/pull/218/changes)
- - the most recent implementation uses the sync.Once wrapper which is what is used here ([src](https://github.com/planetscale/planetscale-go/blob/fc52a46d9dbf27af536f5e9725b19024c6deef3d/planetscale/client.go#L168))
