### PR TITLE
Add once support to IStream

### DIFF
--- a/typescript/src/types/client.ts
+++ b/typescript/src/types/client.ts
@@ -10,6 +10,7 @@ export interface StreamOptions {
 
 export interface IStream {
   on(event: "report", listener: (report: Report) => void): this;
+  once(event: "report", listener: (report: Report) => void): this;
   on(event: "error", listener: (error: Error) => void): this;
   on(event: "disconnected", listener: () => void): this;
   on(

--- a/typescript/tests/unit/stream/stream/events.test.ts
+++ b/typescript/tests/unit/stream/stream/events.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { Stream } from "../../../../src/stream";
-import { Config } from "../../../../src/types/client";
+import { Config, IStream } from "../../../../src/types/client";
 import { LogLevel } from "../../../../src/types/logger";
 import * as originDiscovery from "../../../../src/utils/origin-discovery";
 
@@ -91,6 +91,25 @@ describe("Stream - Event Re-emission", () => {
 
     expect(reconnectingSpy).toHaveBeenCalledTimes(2);
     expect(reconnectingSpy).toHaveBeenCalledWith(reconnectingInfo);
+  });
+
+  it("supports one-time report listeners through IStream", () => {
+    const typedStream: IStream = stream;
+    const reportListener = jest.fn();
+    const report = {
+      feedID: "0x0003" + "1".repeat(60),
+      fullReport: "0x1234",
+      validFromTimestamp: 1,
+      observationsTimestamp: 2,
+    };
+
+    expect(typedStream.once("report", reportListener)).toBe(typedStream);
+
+    stream.emit("report", report);
+    stream.emit("report", report);
+
+    expect(reportListener).toHaveBeenCalledTimes(1);
+    expect(reportListener).toHaveBeenCalledWith(report);
   });
 
   it("re-emits 'connection-lost' event exactly once per transition", async () => {


### PR DESCRIPTION
Fixes #61

## Summary
- Expose the existing EventEmitter once capability through the public IStream interface for report events.
- Add regression coverage that verifies the IStream type and one-time listener behavior.

## Validation
- npx jest tests/unit/stream/stream/events.test.ts --runInBand (5 pass)
- npm run test:unit (19 suites, 390 tests passed)
- npx tsc --noEmit
- npm run lint
- npx prettier --check src/types/client.ts tests/unit/stream/stream/events.test.ts

## Formatting baseline
The repository-wide npm run format:check reports CRLF formatting on 63 existing TypeScript files in this Windows checkout. The two changed files pass the scoped Prettier check; no unrelated formatting rewrite is included.

## Scope
No runtime behavior, dependency, generator, example, or documentation changes.